### PR TITLE
Upgrade Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-FROM archlinux/archlinux:latest
-
-# Install the base packages and any dependencies
-RUN pacman -Syu --noconfirm && pacman -S --noconfirm python-pip git
+# Pulling python docker image directly
+FROM python:alpine3.17
 
 # Changing the working directory
 WORKDIR /app


### PR DESCRIPTION
Reducing image size from 1GB to 100MB by pulling only python docker image instead of whole OS